### PR TITLE
Fix ERR_INVALID_PACKAGE_TARGET error

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "exports": {
     ".": "./index.js",
     "./+babel": "./+babel.js",
-    "/+compatibility": "+compatibility.js",
+    "./+compatibility": "./+compatibility.js",
     "./+mocha": "./+mocha.js",
     "./+node": "./+node.js",
     "./+prettier": "./+prettier.js",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -45,6 +45,7 @@ describe('@hidoo/eslint-config', () => {
 
     const config = await eslint.calculateConfigForFile('_.js');
 
+    assert(require.resolve('@hidoo/eslint-config/+babel'));
     assert(config.parser.indexOf('@babel/eslint-parser') !== -1);
     assert.deepEqual(config.env, baseConfig.env);
     assert.deepEqual(config.settings, baseConfig.settings);
@@ -67,6 +68,7 @@ describe('@hidoo/eslint-config', () => {
 
     const config = await eslint.calculateConfigForFile('_.js');
 
+    assert(require.resolve('@hidoo/eslint-config/+compatibility'));
     assert.deepEqual(config.env, baseConfig.env);
     assert.deepEqual(config.settings, baseConfig.settings);
     assert.deepEqual(config.plugins, [...baseConfig.plugins, 'compat']);
@@ -84,6 +86,7 @@ describe('@hidoo/eslint-config', () => {
 
     const config = await eslint.calculateConfigForFile('_.js');
 
+    assert(require.resolve('@hidoo/eslint-config/+mocha'));
     assert.deepEqual(config.env, { ...baseConfig.env, mocha: true });
     assert.deepEqual(config.settings, baseConfig.settings);
     assert.deepEqual(config.plugins, [...baseConfig.plugins, 'mocha']);
@@ -101,6 +104,7 @@ describe('@hidoo/eslint-config', () => {
 
     const config = await eslint.calculateConfigForFile('_.js');
 
+    assert(require.resolve('@hidoo/eslint-config/+node'));
     assert.deepEqual(config.env, { ...baseConfig.env, node: true });
     assert.deepEqual(config.settings, baseConfig.settings);
     assert.deepEqual(config.plugins, [...baseConfig.plugins, 'node']);


### PR DESCRIPTION
Fix following error and add test cases for `exports` fields in `package.json`.

```
Error [ERR_INVALID_PACKAGE_TARGET]: Invalid "exports" target "+compatibility.js" defined for './+compatibility' in the package config /path/to/eslint-config/package.json imported from /path/to/eslint-config/test/index.test.js; targets must start with "./"
```