### PR TITLE
fix(stylistic): remove deprecated rule

### DIFF
--- a/lib/stylistic.js
+++ b/lib/stylistic.js
@@ -79,7 +79,6 @@ module.exports = {
     '@stylistic/jsx-equals-spacing': 'off',
     '@stylistic/jsx-function-call-newline': ['error', 'always'],
     '@stylistic/jsx-first-prop-new-line': 'off',
-    '@stylistic/jsx-indent': 'off',
     '@stylistic/jsx-indent-props': 'off',
     '@stylistic/jsx-max-props-per-line': 'off',
     '@stylistic/jsx-newline': 'off',


### PR DESCRIPTION
### Changes
+ Remove deprecated rule `@stylistic/jsx-indent`