### PR TITLE
chore(release): publish 2.0.0-beta.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,108 @@
+# [2.0.0-beta.0](https://github.com/hidoo/eslint-config/compare/v1.3.1...v2.0.0-beta.0) (2025-04-14)
+
+
+* fix!: migrate to flat config ([c54a1d3](https://github.com/hidoo/eslint-config/commit/c54a1d37f785c289b61701290196e649ffb520ae))
+
+
+### Bug Fixes
+
+* **+node:** replace rule prefixes to n ([e04497b](https://github.com/hidoo/eslint-config/commit/e04497bc6cd9913f5503bb33a70f09c50b67c84f))
+* **deps:** replace dependency eslint-plugin-node with eslint-plugin-n 14.0.0 ([3162a76](https://github.com/hidoo/eslint-config/commit/3162a76e273f36fc698fac3561a11ba93df75330))
+* **deps:** update babel monorepo to v7.26.10 ([#464](https://github.com/hidoo/eslint-config/issues/464)) ([930327a](https://github.com/hidoo/eslint-config/commit/930327a7435bf6efcd50a88f9f6c72ad801edad9))
+* **deps:** update babel monorepo to v7.26.8 ([#452](https://github.com/hidoo/eslint-config/issues/452)) ([f8efd85](https://github.com/hidoo/eslint-config/commit/f8efd8578d12e5ad59d12c61b6d817baa1041e33))
+* **deps:** update dependency @babel/eslint-parser to v7.25.0 ([f2dfdba](https://github.com/hidoo/eslint-config/commit/f2dfdbaa7cf9b359f1b2d86e00609abbf2e13861))
+* **deps:** update dependency @babel/eslint-parser to v7.26.5 ([#442](https://github.com/hidoo/eslint-config/issues/442)) ([491177d](https://github.com/hidoo/eslint-config/commit/491177d7edab60f01f6dbc1e5b3271fe242f8baf))
+* **deps:** update dependency @babel/eslint-parser to v7.27.0 ([#467](https://github.com/hidoo/eslint-config/issues/467)) ([6f39664](https://github.com/hidoo/eslint-config/commit/6f396649c84a05c828515c560393942c6f63c421))
+* **deps:** update dependency @stylistic/eslint-plugin to v1.7.0 ([e7d60a8](https://github.com/hidoo/eslint-config/commit/e7d60a8e114e2b567fe087c168a2437605b54dba))
+* **deps:** update dependency @stylistic/eslint-plugin to v1.7.2 ([1f2558e](https://github.com/hidoo/eslint-config/commit/1f2558ed17156f740d2494060dac42d1393626d8))
+* **deps:** update dependency @stylistic/eslint-plugin to v1.8.0 ([adcb345](https://github.com/hidoo/eslint-config/commit/adcb345937dfcc23042d4becde5615f4115049da))
+* **deps:** update dependency @stylistic/eslint-plugin to v2 ([aae943d](https://github.com/hidoo/eslint-config/commit/aae943ded2a29acbf0cbfdcb801c80b3b42ff8fe))
+* **deps:** update dependency @stylistic/eslint-plugin to v2.10.1 ([9721ad5](https://github.com/hidoo/eslint-config/commit/9721ad51a25b97e306e80890970b42639a701820))
+* **deps:** update dependency @stylistic/eslint-plugin to v2.11.0 ([#423](https://github.com/hidoo/eslint-config/issues/423)) ([1e3d45a](https://github.com/hidoo/eslint-config/commit/1e3d45af637459710ba17bcd999a4807d707d0a8))
+* **deps:** update dependency @stylistic/eslint-plugin to v2.12.1 ([#435](https://github.com/hidoo/eslint-config/issues/435)) ([8305540](https://github.com/hidoo/eslint-config/commit/8305540f8ea356efc70a7565e59f19381e4fce3c))
+* **deps:** update dependency @stylistic/eslint-plugin to v2.13.0 ([#446](https://github.com/hidoo/eslint-config/issues/446)) ([5de6a3a](https://github.com/hidoo/eslint-config/commit/5de6a3ad624511c1501951c064e99b5bd38fd4a9))
+* **deps:** update dependency @stylistic/eslint-plugin to v2.2.0 ([93c42fa](https://github.com/hidoo/eslint-config/commit/93c42fae32c134d9b86390d86f38b141f9429554))
+* **deps:** update dependency @stylistic/eslint-plugin to v2.2.2 ([e9554c9](https://github.com/hidoo/eslint-config/commit/e9554c938b5e46a940d205a56e26dda6c5dc9a89))
+* **deps:** update dependency @stylistic/eslint-plugin to v2.3.0 ([9430a4e](https://github.com/hidoo/eslint-config/commit/9430a4ebda982fb591c1fec681a4fcc580e38c0f))
+* **deps:** update dependency @stylistic/eslint-plugin to v2.4.0 ([56de401](https://github.com/hidoo/eslint-config/commit/56de401dde6be342221dc7cf5d54bd5e64618157))
+* **deps:** update dependency @stylistic/eslint-plugin to v2.6.1 ([dc77972](https://github.com/hidoo/eslint-config/commit/dc77972944c1bd03a9b99b3ad4f9996d4b3b0f4a))
+* **deps:** update dependency @stylistic/eslint-plugin to v2.6.2 ([76d31de](https://github.com/hidoo/eslint-config/commit/76d31dee144e6a6bc7e58d667365578e633513ba))
+* **deps:** update dependency @stylistic/eslint-plugin to v2.6.4 ([c5692aa](https://github.com/hidoo/eslint-config/commit/c5692aaaa9de8a04b3d3215f3a842048bf61b9a0))
+* **deps:** update dependency @stylistic/eslint-plugin to v2.7.2 ([3ae98c9](https://github.com/hidoo/eslint-config/commit/3ae98c9c6e2bc47e5346429fc48ffa009ba4d2ed))
+* **deps:** update dependency @stylistic/eslint-plugin to v2.8.0 ([e46c3ab](https://github.com/hidoo/eslint-config/commit/e46c3ab65e6f1a3fada000450b1e119d46bbf676))
+* **deps:** update dependency @stylistic/eslint-plugin to v2.9.0 ([cd14fc9](https://github.com/hidoo/eslint-config/commit/cd14fc9ae118ce63e7624ae987750ed46754e609))
+* **deps:** update dependency eslint-config-prettier to v10 ([4fb0d13](https://github.com/hidoo/eslint-config/commit/4fb0d131d7936853e8176ce7982cae9c0a8795fb))
+* **deps:** update dependency eslint-plugin-compat to v5 ([4f81001](https://github.com/hidoo/eslint-config/commit/4f810018b84028290b1c16e36df8b2131b2c5914))
+* **deps:** update dependency eslint-plugin-compat to v6 ([cc681ce](https://github.com/hidoo/eslint-config/commit/cc681cee049b14ab48c9b91f764c7fbb7355a0c8))
+* **deps:** update dependency eslint-plugin-compat to v6.0.1 ([00e7519](https://github.com/hidoo/eslint-config/commit/00e7519b65e7981cc095aa4443d44c9baf8ad449))
+* **deps:** update dependency eslint-plugin-compat to v6.0.2 ([#433](https://github.com/hidoo/eslint-config/issues/433)) ([654d74c](https://github.com/hidoo/eslint-config/commit/654d74c74f45008528087e4a4a94a0ef7f3351cb))
+* **deps:** update dependency eslint-plugin-import to v2.30.0 ([c3bf527](https://github.com/hidoo/eslint-config/commit/c3bf52788a688dc03d161d206182250a8a191d8d))
+* **deps:** update dependency eslint-plugin-import to v2.31.0 ([456241b](https://github.com/hidoo/eslint-config/commit/456241bb0967bb9ad84d150689a3c186d399d7ec))
+* **deps:** update dependency eslint-plugin-jsdoc to v48.11.0 ([a886fa9](https://github.com/hidoo/eslint-config/commit/a886fa9e6c7acf727c72398c94a98c60b6a1d13b))
+* **deps:** update dependency eslint-plugin-jsdoc to v48.2.12 ([2380a9a](https://github.com/hidoo/eslint-config/commit/2380a9abac56259bedd35e4ae29df7fe66af1cbf))
+* **deps:** update dependency eslint-plugin-jsdoc to v48.2.15 ([f430ed4](https://github.com/hidoo/eslint-config/commit/f430ed48da700121d1c821232e51fa9627c69acb))
+* **deps:** update dependency eslint-plugin-jsdoc to v48.2.2 ([fbaa5c0](https://github.com/hidoo/eslint-config/commit/fbaa5c0ce8c5a03f7fc6e7b6a8982f595a96ec7f))
+* **deps:** update dependency eslint-plugin-jsdoc to v48.2.3 ([17bcd93](https://github.com/hidoo/eslint-config/commit/17bcd939ef879b3e3ac2963ecaad2edb714b7446))
+* **deps:** update dependency eslint-plugin-jsdoc to v48.2.4 ([053df0c](https://github.com/hidoo/eslint-config/commit/053df0c1123ab8614d777a4152d365dae107d6a3))
+* **deps:** update dependency eslint-plugin-jsdoc to v48.2.5 ([ec5838a](https://github.com/hidoo/eslint-config/commit/ec5838a15ef566acbbe7bfe68253d46a99cf3f64))
+* **deps:** update dependency eslint-plugin-jsdoc to v48.2.6 ([9fcbc0e](https://github.com/hidoo/eslint-config/commit/9fcbc0e8df1d435a84884484340fd2eff914ac64))
+* **deps:** update dependency eslint-plugin-jsdoc to v48.2.7 ([2870dcb](https://github.com/hidoo/eslint-config/commit/2870dcb272135d80619b88b1a96764fea150e967))
+* **deps:** update dependency eslint-plugin-jsdoc to v48.2.9 ([5fea1d0](https://github.com/hidoo/eslint-config/commit/5fea1d0595b5e80fdbd9745d0b666b8020a44f7a))
+* **deps:** update dependency eslint-plugin-jsdoc to v48.5.0 ([72c287c](https://github.com/hidoo/eslint-config/commit/72c287c43926ea5704bc4a8e509c252de564ed23))
+* **deps:** update dependency eslint-plugin-jsdoc to v48.7.0 ([dbff387](https://github.com/hidoo/eslint-config/commit/dbff387076b918db23d556ef7989533588e32030))
+* **deps:** update dependency eslint-plugin-jsdoc to v48.8.3 ([ad431a0](https://github.com/hidoo/eslint-config/commit/ad431a09017aff99dce0f83bf4399dac96f93d03))
+* **deps:** update dependency eslint-plugin-jsdoc to v50 ([0b41ae0](https://github.com/hidoo/eslint-config/commit/0b41ae01bf3b2a05d04d6d2d951e348388199ca0))
+* **deps:** update dependency eslint-plugin-jsdoc to v50.2.3 ([c8561f7](https://github.com/hidoo/eslint-config/commit/c8561f71fd8ab2b25c0ea5f0df2257afb05f18c3))
+* **deps:** update dependency eslint-plugin-jsdoc to v50.2.4 ([445a26a](https://github.com/hidoo/eslint-config/commit/445a26aa5b9ba7b6e04029839e0a03125c60593a))
+* **deps:** update dependency eslint-plugin-jsdoc to v50.3.0 ([79f7288](https://github.com/hidoo/eslint-config/commit/79f72881869b36d25828e4514b1a713d8ae3aacc))
+* **deps:** update dependency eslint-plugin-jsdoc to v50.3.1 ([1fc4f2b](https://github.com/hidoo/eslint-config/commit/1fc4f2b228f1aa8f05d27607db6a00039ad02906))
+* **deps:** update dependency eslint-plugin-jsdoc to v50.3.2 ([d543232](https://github.com/hidoo/eslint-config/commit/d543232787c6161220888515c96a75a5ef116432))
+* **deps:** update dependency eslint-plugin-jsdoc to v50.4.3 ([e6ff265](https://github.com/hidoo/eslint-config/commit/e6ff26569cd122803e0813c9dea30503b61db825))
+* **deps:** update dependency eslint-plugin-jsdoc to v50.5.0 ([#420](https://github.com/hidoo/eslint-config/issues/420)) ([ba7a467](https://github.com/hidoo/eslint-config/commit/ba7a4675f267a7356eefba725f2142a5d2b5109f))
+* **deps:** update dependency eslint-plugin-jsdoc to v50.6.0 ([#429](https://github.com/hidoo/eslint-config/issues/429)) ([ecccab0](https://github.com/hidoo/eslint-config/commit/ecccab0783778c7e0cf91c7a8dfa34c0fafd2e62))
+* **deps:** update dependency eslint-plugin-jsdoc to v50.6.1 ([#434](https://github.com/hidoo/eslint-config/issues/434)) ([36a9282](https://github.com/hidoo/eslint-config/commit/36a92828031ba79f153440faefd4f484404b8504))
+* **deps:** update dependency eslint-plugin-jsdoc to v50.6.3 ([#445](https://github.com/hidoo/eslint-config/issues/445)) ([3eb93c2](https://github.com/hidoo/eslint-config/commit/3eb93c26f859a321c219339007618512051c8d85))
+* **deps:** update dependency eslint-plugin-jsdoc to v50.6.9 ([#465](https://github.com/hidoo/eslint-config/issues/465)) ([1e8df85](https://github.com/hidoo/eslint-config/commit/1e8df85318316cf393ecc2a55832689d6cd2cd5f))
+* **deps:** update dependency eslint-plugin-mocha to v10.4.2 ([a5a2aba](https://github.com/hidoo/eslint-config/commit/a5a2abaa2f02812245fe99d939f59dcb1a470362))
+* **deps:** update dependency eslint-plugin-mocha to v10.4.3 ([960c3a4](https://github.com/hidoo/eslint-config/commit/960c3a442e300509f296bd109486939e809b6424))
+* **deps:** update dependency eslint-plugin-mocha to v10.5.0 ([646d9ad](https://github.com/hidoo/eslint-config/commit/646d9add91597539dd9d69d0dd387bc0d711524c))
+* **deps:** update dependency eslint-plugin-n to v17 ([94d3058](https://github.com/hidoo/eslint-config/commit/94d30585f4ce78102c5262a02824ed43a5041576))
+* **deps:** update dependency eslint-plugin-n to v17.10.1 ([b7d30e1](https://github.com/hidoo/eslint-config/commit/b7d30e1b6401fa7d03c9a85c06a19674e202d18a))
+* **deps:** update dependency eslint-plugin-n to v17.10.2 ([2232a3f](https://github.com/hidoo/eslint-config/commit/2232a3f7c0228d12141db080513b983151cada80))
+* **deps:** update dependency eslint-plugin-n to v17.10.3 ([8e1d7fd](https://github.com/hidoo/eslint-config/commit/8e1d7fd2ccaf16f61e67151790474bdcbbc5075c))
+* **deps:** update dependency eslint-plugin-n to v17.11.1 ([5786416](https://github.com/hidoo/eslint-config/commit/5786416e6997ff72064e2c48e131616d62ebee20))
+* **deps:** update dependency eslint-plugin-n to v17.12.0 ([c837cf5](https://github.com/hidoo/eslint-config/commit/c837cf5d96dc3ee65796fe1a0ff6b51ea3d7c886))
+* **deps:** update dependency eslint-plugin-n to v17.13.1 ([#417](https://github.com/hidoo/eslint-config/issues/417)) ([7fc4c96](https://github.com/hidoo/eslint-config/commit/7fc4c96de0d3ca93fcb18b0d44d4b0e2cf181708))
+* **deps:** update dependency eslint-plugin-n to v17.13.2 ([#418](https://github.com/hidoo/eslint-config/issues/418)) ([eaacdb0](https://github.com/hidoo/eslint-config/commit/eaacdb08d17c09b12a71abbd09cbe1088c65bd9d))
+* **deps:** update dependency eslint-plugin-n to v17.14.0 ([#424](https://github.com/hidoo/eslint-config/issues/424)) ([7871588](https://github.com/hidoo/eslint-config/commit/7871588bbd29e65d30991b51a81e80a61efe69f1))
+* **deps:** update dependency eslint-plugin-n to v17.15.0 ([#436](https://github.com/hidoo/eslint-config/issues/436)) ([4aa214e](https://github.com/hidoo/eslint-config/commit/4aa214e10a705587095b7e7cf8b2112b6e5e547e))
+* **deps:** update dependency eslint-plugin-n to v17.15.1 ([#438](https://github.com/hidoo/eslint-config/issues/438)) ([c1b7be8](https://github.com/hidoo/eslint-config/commit/c1b7be8ad1bc3240df37cb189f0403bf233694a8))
+* **deps:** update dependency eslint-plugin-n to v17.16.1 ([#460](https://github.com/hidoo/eslint-config/issues/460)) ([1299711](https://github.com/hidoo/eslint-config/commit/12997110083c3e2080c7c270d16e25033dc0cda6))
+* **deps:** update dependency eslint-plugin-n to v17.16.2 ([#466](https://github.com/hidoo/eslint-config/issues/466)) ([9f30092](https://github.com/hidoo/eslint-config/commit/9f30092283833e4f4b268a8a8f6dfd2b6baeb8e7))
+* **deps:** update dependency eslint-plugin-n to v17.17.0 ([#468](https://github.com/hidoo/eslint-config/issues/468)) ([e7fce59](https://github.com/hidoo/eslint-config/commit/e7fce59ed106297d997a9f94f3cccb2e84ba46f8))
+* **deps:** update dependency eslint-plugin-n to v17.3.1 ([b9df312](https://github.com/hidoo/eslint-config/commit/b9df312a699943931ed8bc71be8efd037ef42659))
+* **deps:** update dependency eslint-plugin-n to v17.4.0 ([38e6064](https://github.com/hidoo/eslint-config/commit/38e60642d00d6a494c18283821a23154c6d7121b))
+* **deps:** update dependency eslint-plugin-n to v17.6.0 ([665bdc5](https://github.com/hidoo/eslint-config/commit/665bdc5b2c677b8a21cfaf48d44524975699ad8c))
+* **deps:** update dependency eslint-plugin-n to v17.7.0 ([4e6e1a5](https://github.com/hidoo/eslint-config/commit/4e6e1a5faae268eb82e521d92332b7effbe8c509))
+* **deps:** update dependency eslint-plugin-n to v17.8.1 ([39484d2](https://github.com/hidoo/eslint-config/commit/39484d2695d24855440323abdff789908863e8ed))
+* **deps:** update dependency eslint-plugin-n to v17.9.0 ([245c184](https://github.com/hidoo/eslint-config/commit/245c1840bc81abbdb77f41edf76abe8fd96b7ed6))
+* **deps:** update dependency eslint-plugin-sort-class-members to v1.21.0 ([39d7d4a](https://github.com/hidoo/eslint-config/commit/39d7d4a128cae2dcdd2cd7319d6c80b071f5dbd1))
+* **stylistic:** remove deprecated rule ([c62bab2](https://github.com/hidoo/eslint-config/commit/c62bab2e181f2d7c86d540d50ae76d889ae51774))
+* tweaks config for this project ([fdc4581](https://github.com/hidoo/eslint-config/commit/fdc45814f677bcd8c8e17d7f112d8eddeee73e14))
+
+
+### Features
+
+* **stylistic:** support rules that added in v2 ([144f472](https://github.com/hidoo/eslint-config/commit/144f47279b22274c4fc1a80036ef96d952db2450))
+
+
+### BREAKING CHANGES
+
+* Drop support eslint v8 and .eslintrc.
+* Remove eslint-comments plugin. Use instead reportUnusedDisableDirectives.
+
+
+
 ## [1.3.1](https://github.com/hidoo/eslint-config/compare/v1.3.0...v1.3.1) (2024-03-11)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hidoo/eslint-config",
-  "version": "1.3.1",
+  "version": "2.0.0-beta.0",
   "description": "Shareable config for ESlint.",
   "packageManager": "pnpm@10.8.0",
   "engines": {


### PR DESCRIPTION
### BREAKING CHANGES
+ Drop support eslint v8 and .eslintrc.
+ Change to use reportUnusedDisableDirectives instead of eslint-comments plugin.