### PR TITLE
chore(release): publish 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# [2.0.0](https://github.com/hidoo/eslint-config/compare/v2.0.0-beta.0...v2.0.0) (2025-04-16)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @stylistic/eslint-plugin to v4 ([44284e0](https://github.com/hidoo/eslint-config/commit/44284e09092cbd6a75a95d007055aa7069a8ce1f))
+
+
+### Features
+
+* change globals to be importable as named export ([20596ed](https://github.com/hidoo/eslint-config/commit/20596ed5b744657c60b7b1d32b11ef5ef88303a6))
+
+
+
 # [2.0.0-beta.0](https://github.com/hidoo/eslint-config/compare/v1.3.1...v2.0.0-beta.0) (2025-04-14)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hidoo/eslint-config",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0",
   "description": "Shareable config for ESlint.",
   "packageManager": "pnpm@10.8.0",
   "engines": {


### PR DESCRIPTION
### BREAKING CHANGES
+ Drop support eslint v8 and `.eslintrc`.
+ Change to use `reportUnusedDisableDirectives` instead of eslint-comments plugin.